### PR TITLE
Update README.md - Differentiate `mpv-launcher.conf` from `mpv.conf`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ mpv://play?file=https%3A%2F%2Fyoutu.be%2FXCs7FacjHQY&file=https%3A%2F%2Fyoutu.be
 
 mpv-launcher can be configured by creating a configuration file at `%APPDATA%\mpv\mpv-launcher.conf`. This file follows a similar syntax to `mpv.conf`.
 
-Example configuration file:
+Example `mpv-launcher.conf` file:
 ```
 single-instance-behavior=replace
 sort-file-explorer-selection=yes
 raise-existing-window=yes
 ```
+mpv configuration options such as `keep-open=yes` ([full list](https://github.com/mpv-player/mpv/blob/v0.36.0/DOCS/man/options.rst)) should be created in the same directory at `%APPDATA%\mpv\mpv.conf` ([official docs](https://github.com/mpv-player/mpv/blob/v0.36.0/DOCS/man/mpv.rst#files-on-windows)), while the options specific to `mpv-launcher.conf` are as follows:
 
 ## Options
 


### PR DESCRIPTION
Clarify which config options apply to mpv-launcher and which apply to mpv itself.

I created this in the hopes of saving future people some hassle after it took me an hour to figure out how to get mpv-msix to stop autoclosing when videos finish playing.